### PR TITLE
[fix] fix summary not show up when outside the app

### DIFF
--- a/app/src/main/java/org/muilab/noti/summary/MainActivity.kt
+++ b/app/src/main/java/org/muilab/noti/summary/MainActivity.kt
@@ -59,7 +59,6 @@ class MainActivity : ComponentActivity() {
         }
         bindService(summaryServiceIntent, summaryServiceConnection, Context.BIND_AUTO_CREATE)
 
-
         val sharedPref = this.getSharedPreferences("user", Context.MODE_PRIVATE)
         setContent {
 
@@ -133,6 +132,7 @@ class MainActivity : ComponentActivity() {
         registerReceiver(allNotiReturnReceiver, allNotiFilter)
         val newStatusFilter = IntentFilter("edu.mui.noti.summary.UPDATE_STATUS")
         registerReceiver(newStatusReceiver, newStatusFilter)
+        sumViewModel.updateStatusText()
     }
 
     override fun onPause() {
@@ -197,11 +197,7 @@ class MainActivity : ComponentActivity() {
     private val newStatusReceiver = object : BroadcastReceiver() {
         override fun onReceive(context: Context?, intent: Intent?) {
             if (intent?.action == "edu.mui.noti.summary.UPDATE_STATUS") {
-                val newStatus = intent.getStringExtra("newStatus")
-                val activeNotifications = intent.getParcelableArrayListExtra<NotiUnit>("activeNotis")
-                if (newStatus != null && activeNotifications != null) {
-                    sumViewModel.updateStatusText(newStatus, activeNotifications)
-                }
+                sumViewModel.updateStatusText()
             }
         }
     }

--- a/app/src/main/java/org/muilab/noti/summary/service/SummaryService.kt
+++ b/app/src/main/java/org/muilab/noti/summary/service/SummaryService.kt
@@ -244,8 +244,6 @@ class SummaryService : Service(), LifecycleOwner {
             }
 
             updateStatusText(responseStr)
-            statusText = ""
-            notiInProcess = arrayListOf()
             if (isScheduled)
                 notifySummary(responseStr)
             responseStr // return value
@@ -356,8 +354,6 @@ class SummaryService : Service(), LifecycleOwner {
     private fun updateStatusText(newStatus: String) {
         statusText = newStatus
         val updateIntent = Intent("edu.mui.noti.summary.UPDATE_STATUS")
-        updateIntent.putExtra("newStatus", newStatus)
-        updateIntent.putParcelableArrayListExtra("activeNotis", notiInProcess)
         sendBroadcast(updateIntent)
     }
 


### PR DESCRIPTION
- when generating the sum and the app passes the onCreate -> update summaryText from SummaryService
- when generating the sum and the app passes the onResume -> update summaryText from SummaryService
- when the sum is generated and the app passes the onCreate -> update summaryText from SharedPref
- when the sum is generated and the app passes the onCreate -> update summaryText from SummaryService